### PR TITLE
Restore setOverwinter function

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -28,9 +28,13 @@ function Transaction () {
   this.ins = []
   this.outs = []
   this.joinsplits = []
-  this.versionGroupId = '0x03c48270'
-  this.expiry = 0
-  this.zcash = true
+}
+
+Transaction.prototype.setOverwinter = (expiry, versionGroupId, version) => {
+  this.zcash = true;
+  this.version = Math.max((version||3), 3);
+  this.versionGroupId=(versionGroupId||0x03c48270);
+  this.expiry=(expiry||0);
 }
 
 Transaction.DEFAULT_SEQUENCE = 0xffffffff


### PR DESCRIPTION
This function is required by z-nomp in order to allow both forks that have overwinter as well as forks that don't.