### PR TITLE
Fixed Overwinter decode fails

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -30,7 +30,7 @@ function Transaction () {
   this.joinsplits = []
 }
 
-Transaction.prototype.setOverwinter = (expiry, versionGroupId, version) => {
+Transaction.prototype.setOverwinter = function (expiry, versionGroupId, version) {
   this.zcash = true;
   this.version = Math.max((version||3), 3);
   this.versionGroupId=(versionGroupId||0x03c48270);
@@ -366,8 +366,13 @@ Transaction.prototype.__byteLength = function (__allowWitness) {
     this.outs.reduce(function (sum, output) { return sum + 8 + varSliceSize(output.script) }, 0) +
     (hasWitnesses ? this.ins.reduce(function (sum, input) { return sum + vectorSize(input.witness) }, 0) : 0) +
     this.joinsplitByteLength() +
-    (this.version === 3 ? 12 : 0)
-  )
+	//need to figure out what the below commented out line does. doesn't work with some coins.
+	//(this.version === 3 ? 12 : 0)
+	//this.versionGroupId and this.expiry are the original lines 
+	//and were removed. added back to stay functional.
+	(this.versionGroupId == null ? 0 : 4) +
+	(this.expiry == null ? 0 : 4)
+   )
 }
 
 Transaction.prototype.clone = function () {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -23,7 +23,7 @@ function vectorSize (someVector) {
 }
 
 function Transaction () {
-  this.version = 3
+  this.version = 1
   this.locktime = 0
   this.ins = []
   this.outs = []

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -366,12 +366,8 @@ Transaction.prototype.__byteLength = function (__allowWitness) {
     this.outs.reduce(function (sum, output) { return sum + 8 + varSliceSize(output.script) }, 0) +
     (hasWitnesses ? this.ins.reduce(function (sum, input) { return sum + vectorSize(input.witness) }, 0) : 0) +
     this.joinsplitByteLength() +
-	//need to figure out what the below commented out line does. doesn't work with some coins.
-	//(this.version === 3 ? 12 : 0)
-	//this.versionGroupId and this.expiry are the original lines 
-	//and were removed. added back to stay functional.
-	(this.versionGroupId == null ? 0 : 4) +
-	(this.expiry == null ? 0 : 4)
+	//overwinter added byte length
+	(this.version === 3 ? 8 : 0)
    )
 }
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -488,10 +488,10 @@ TransactionBuilder.prototype.setExpiry = function (expiry) {
   this.tx.expiry = expiry
 }
 
-TransactionBuilder.prototype.setVersionGroupId = function (versiongroupid) {
-  typeforce(types.UInt32, versiongroupid)
+TransactionBuilder.prototype.setVersionGroupId = function (versionGroupId) {
+  typeforce(types.UInt32, versionGroupId)
 
-  this.tx.versiongroupid = versiongroupid
+  this.tx.versionGroupId = versionGroupId
 }
 
 TransactionBuilder.prototype.setLockTime = function (locktime) {


### PR DESCRIPTION
Fixed typos that may have caused some issues. 

setOverwinter() is now a function again and not an array.

Changed line 369 in transaction.js back to their original. Not sure exactly what it does but it seems to work with everything with this change. Needs tested on zcash. If it fails we need to make this more dynamic or configurable.